### PR TITLE
feat: return form reference on submit to allow reset

### DIFF
--- a/playground/App.tsx
+++ b/playground/App.tsx
@@ -66,8 +66,9 @@ export const App = () => {
       fieldRendererMap={{
         avatar: AvatarRenderer,
       }}
-      onSubmit={(data) => {
+      onSubmit={(data, form) => {
         console.log(data);
+        form.reset();
       }}
       style={{
         display: "flex",

--- a/src/form-renderer.tsx
+++ b/src/form-renderer.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { UseFormProps } from "react-hook-form";
+import { UseFormProps, UseFormReturn } from "react-hook-form";
 import { z } from "zod";
 import { FieldRenderer, RendererMap } from "./renderer-map";
 import { TSchema, useFormRenderer } from "./use-form-renderer";
@@ -35,7 +35,10 @@ type FormRendererProps<
     [K in TCustomKey]: FieldRenderer<any>;
   }>;
   useFormProps?: UseFormProps<z.infer<TSchema<TShape>>>;
-  onSubmit: (data: z.infer<TSchema<TShape>>) => void;
+  onSubmit: (
+    data: z.infer<TSchema<TShape>>,
+    form: UseFormReturn<z.infer<TSchema<TShape>>>
+  ) => void;
   children: (
     formControls: ReturnType<
       typeof useFormRenderer<
@@ -99,7 +102,10 @@ export const FormRenderer = <
   );
 
   return (
-    <form {...rest} onSubmit={form.handleSubmit(onSubmit)}>
+    <form
+      {...rest}
+      onSubmit={form.handleSubmit((data) => onSubmit(data, form))}
+    >
       {children({ form, controls })}
     </form>
   );


### PR DESCRIPTION
On submit, returns not only the form data but also a reference to the react-hook-form instance.
The main use case would be to reset the form values after submit.