### PR TITLE
Fix broken ES module paths in package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./dist/index.es.js",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs.js"
     }
   },
   "main": "./dist/index.cjs.js",
-  "module": "./dist/index.es.js",
+  "module": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
Fixes #44 

@hackingharold Could you have a look at this when you can? This fix is quite urgent since it makes the package otherwise unusable in ESM environments. 