### PR TITLE
Configure Vite to exclude Peer deps from build -> 99.9% bundle size reduction

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
   },
   "include": ["vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import typescript from '@rollup/plugin-typescript';
 import react from '@vitejs/plugin-react';
 import * as path from 'path';
 import { defineConfig } from 'vite';
+import pkgJson from './package.json';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -30,6 +31,13 @@ export default defineConfig({
       formats: ['es', 'cjs'],
     },
     rollupOptions: {
+      external: [...Object.keys(pkgJson.peerDependencies), 'react/jsx-runtime'],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM',
+        },
+      },
       plugins: [
         typescript({
           outDir: 'dist',


### PR DESCRIPTION
Closes #54 

This fix reduces the bundle size (index.js) from 189Kb to 3.7K